### PR TITLE
Remove unused react-query import

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,6 +1,5 @@
 
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import Index from "./pages/Index";
 import Login from "./pages/Login";


### PR DESCRIPTION
## Summary
- clean up `src/routes.tsx` by removing `QueryClient` and `QueryClientProvider` import

## Testing
- `npm run lint` *(fails: 120 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6846dce429288320bb1fd5ddbb029cac