### PR TITLE
Update query key for project manager fetch

### DIFF
--- a/src/hooks/use-team-management.tsx
+++ b/src/hooks/use-team-management.tsx
@@ -9,7 +9,7 @@ export const useTeamManagement = (projectId: string) => {
 
   // Récupération des informations du projet
   const { data: project } = useQuery({
-    queryKey: ["project", projectId],
+    queryKey: ["teamProjectManager", projectId],
     queryFn: async () => {
       const { data, error } = await supabase
         .from("projects")


### PR DESCRIPTION
## Summary
- use a unique react-query key when fetching project manager data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaecc0cd48320b1b9aefeb92d5795